### PR TITLE
Don't do reverse DNS lookups on IP addresses

### DIFF
--- a/WarhawkReborn/Service.cs
+++ b/WarhawkReborn/Service.cs
@@ -74,8 +74,8 @@ namespace WarhawkReborn
                 byte[] bip = null;
                 try
                 {
-                    var ip = Dns.GetHostEntry(e.Hostname);
-                    foreach (var i in ip.AddressList)
+                    var ips = Dns.GetHostAddresses(e.Hostname);
+                    foreach (var i in ips)
                     {
                         if (i.AddressFamily != AddressFamily.InterNetwork) continue;
                         bip = i.GetAddressBytes();


### PR DESCRIPTION
Reverse DNS lookups always fail on certain WAN IPs, which prevents game rooms associated to them from being broadcast in Warhawk's LAN lobby.

This resolves that issue by replacing Dns.GetHostEntry() with Dns.GetHostAddresses(). The latter only performs a reverse DNS lookup when a host name is passed to it. If an IP address is provided, it returns the IP as-is.

Fixes #4.