### PR TITLE
Allow and automate window resizing

### DIFF
--- a/WarhawkReborn/MainWindow.xaml
+++ b/WarhawkReborn/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:WarhawkReborn"
         mc:Ignorable="d"
-        Title="Warhawk Reborn" Height="450" Width="328.2" ResizeMode="NoResize" Icon="icon.png">
+        Title="Warhawk Reborn" Height="450" SizeToContent="Width" Icon="icon.png">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="13*"/>
@@ -17,7 +17,7 @@
         <DataGrid x:Name="dg_servers" Margin="10,41.4,9.6,10" Grid.Row="2" AutoGenerateColumns="False" IsReadOnly="True">
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding ID}" Header="#"/>
-                <DataGridTextColumn Binding="{Binding Name}" Header="Name" Width="*"/>
+                <DataGridTextColumn Binding="{Binding Name}" Header="Name"/>
                 <DataGridTextColumn Binding="{Binding Ping}" Header="Ping"/>
                 <DataGridCheckBoxColumn Binding="{Binding IsOnline, Mode=OneWay}" Header="Online"/>
             </DataGrid.Columns>


### PR DESCRIPTION
Causes the app window's width to automatically resize itself to its content's width on startup. Automatic resizing doesn't occur when refreshing. Will benefit #7.

The window can also now be stretched and minimized.