### PR TITLE
Hide IDs and offline rooms

### DIFF
--- a/WarhawkReborn/MainWindow.xaml
+++ b/WarhawkReborn/MainWindow.xaml
@@ -16,10 +16,8 @@
         <Image Margin="10,10,9.6,11.6" Source="logo.png"/>
         <DataGrid x:Name="dg_servers" Margin="10,41.4,9.6,10" Grid.Row="2" AutoGenerateColumns="False" IsReadOnly="True">
             <DataGrid.Columns>
-                <DataGridTextColumn Binding="{Binding ID}" Header="#"/>
                 <DataGridTextColumn Binding="{Binding Name}" Header="Name" Width="*"/>
                 <DataGridTextColumn Binding="{Binding Ping}" Header="Ping"/>
-                <DataGridCheckBoxColumn Binding="{Binding IsOnline, Mode=OneWay}" Header="Online"/>
             </DataGrid.Columns>
         </DataGrid>
         <Label Content="Available servers:" Margin="10,10.4,158.6,0" Grid.Row="2" VerticalAlignment="Top" Height="25"/>

--- a/WarhawkReborn/MainWindow.xaml.cs
+++ b/WarhawkReborn/MainWindow.xaml.cs
@@ -49,10 +49,16 @@ namespace WarhawkReborn
         private void UpdateServerList()
         {
             serverList = api.GetServers();
+            serverList.RemoveAll(isOffline);
             this.service.SetServerList(serverList);
             this.dg_servers.ItemsSource = serverList;
             timeRemaining = 60;
             btn_update_serverlist.Content = String.Format(TEXT_BTN_UPDATE_SERVERLIST, timeRemaining);
+        }
+
+        private static bool isOffline(ServerEntry e)
+        {
+            return e.IsOnline != true;
         }
     }
 }


### PR DESCRIPTION
This removes the "#"/"Online" columns and suppresses permanently-listed rooms that are currently offline.

Those changes should make the app more user-friendly and put it on par with the Android version (whose server list page doesn't show IDs nor offline rooms).