### PR TITLE
Reduce window width

### DIFF
--- a/WarhawkReborn/MainWindow.xaml
+++ b/WarhawkReborn/MainWindow.xaml
@@ -16,7 +16,7 @@
         <Image Margin="10,10,9.6,11.6" Source="logo.png"/>
         <DataGrid x:Name="dg_servers" Margin="10,41.4,9.6,10" Grid.Row="2" AutoGenerateColumns="False" IsReadOnly="True">
             <DataGrid.Columns>
-                <DataGridTextColumn Binding="{Binding Name}" Header="Name" Width="*"/>
+                <DataGridTextColumn Binding="{Binding Name}" Header="Name"/>
                 <DataGridTextColumn Binding="{Binding PlayersIn}" Header="In"/>
                 <DataGridTextColumn Binding="{Binding PlayersMax}" Header="Max"/>
                 <DataGridTextColumn Binding="{Binding Mode}" Header="Mode"/>


### PR DESCRIPTION
This fixes an issue that was causing the app window to always use 100% screen width, which looked very strange and out of proportion.

#8 removed the name column's full width (Width="*") property. But it was merged in before #7 (which added some adjacent lines). As a result of those PRs being merged in a different order than they were sent in, #7 re-introduced the property that #8 removed.